### PR TITLE
iteration 1.5 completed

### DIFF
--- a/Blog_App-iteration_1.1/Blog.Core/Constants/AdminConstants.cs
+++ b/Blog_App-iteration_1.1/Blog.Core/Constants/AdminConstants.cs
@@ -1,0 +1,22 @@
+namespace Blog.Core.Constants
+{
+    public static class AdminConstants
+    {
+        public static class Routes
+        {
+            public const string Index = "Index";
+            public const string Home = "Home";
+        }
+        
+        public static class SuccessMessages
+        {
+            public const string ReportResolved = "Report has been resolved successfully.";
+            public const string ReportUnresolved = "Report has been marked as unresolved.";
+        }
+        
+        public static class ViewBagKeys
+        {
+            public const string SuccessMessage = "SuccessMessage";
+        }
+    }
+} 

--- a/Blog_App-iteration_1.1/Blog.Core/Constants/CommentConstants.cs
+++ b/Blog_App-iteration_1.1/Blog.Core/Constants/CommentConstants.cs
@@ -14,6 +14,7 @@ namespace Blog.Core.Constants
             public const string NoPermissionToRankArticles = "You don't have permission to rank articles.";
             public const string ArticleVoteError = "An error occurred while voting for the article.";
             public const string ArticleDeleteError = "An error occurred while deleting the article.";
+            public const string CannotReportOwnComment = "You cannot report your own comments.";
         }
         public static class Messages
         {
@@ -48,6 +49,7 @@ namespace Blog.Core.Constants
             public const string SignalRNotificationSentForDeletion = "SignalR notification sent for comment deletion {CommentId}";
             public const string SignalRNotificationError = "Error sending SignalR notification for {0}";
             public const string SignalRNotificationSentForUpdate = "SignalR notification sent for updated comment";
+            public const string RepliesUpdated = "Notifying about {ReplyCount} updated replies to comment {CommentId}";
         }
         
         public static class EventNames
@@ -116,6 +118,8 @@ namespace Blog.Core.Constants
             public const string ArticleId = "{id}";
             public const string DefaultErrorAction = "Error";
             public const string DefaultHomeController = "Home";
+            public const string Report = "Report";
+            public const string Block = "Block";
         }
 
         public static class SignalRNotificationTypes

--- a/Blog_App-iteration_1.1/Blog.Core/Interfaces/ICommentService.cs
+++ b/Blog_App-iteration_1.1/Blog.Core/Interfaces/ICommentService.cs
@@ -36,5 +36,25 @@ namespace Blog.Core.Interfaces
         /// Checks if a user can comment on articles
         /// </summary>
         Task<(bool canComment, string message)> CanUserCommentAsync(string userId);
+        
+        /// <summary>
+        /// Reports a comment
+        /// </summary>
+        Task ReportCommentAsync(int commentId, string userId, string reason, string description);
+        
+        /// <summary>
+        /// Sets the block status of a comment
+        /// </summary>
+        Task<CommentViewModel> SetCommentBlockStatusAsync(int commentId, bool isBlocked);
+        
+        /// <summary>
+        /// Gets all reported comments for admin review
+        /// </summary>
+        Task<IEnumerable<ReportViewModel>> GetReportedCommentsAsync();
+        
+        /// <summary>
+        /// Resolves or unresolves a report based on the isResolved parameter
+        /// </summary>
+        Task ResolveReportAsync(int reportId, bool isResolved = true);
     }
 } 

--- a/Blog_App-iteration_1.1/Blog.Core/Models/CommentViewModel.cs
+++ b/Blog_App-iteration_1.1/Blog.Core/Models/CommentViewModel.cs
@@ -24,6 +24,8 @@ namespace Blog.Core.Models
         public int ArticleId { get; set; }
         
         public int? ParentCommentId { get; set; }
+        
+        public bool IsBlocked { get; set; }
     }
     
     public class CreateCommentViewModel

--- a/Blog_App-iteration_1.1/Blog.Core/Models/ReportViewModel.cs
+++ b/Blog_App-iteration_1.1/Blog.Core/Models/ReportViewModel.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Blog.Core.Models
+{
+    public class ReportViewModel
+    {
+        public int Id { get; set; }
+        public string Reason { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public bool IsResolved { get; set; }
+        public DateTime? ResolvedAt { get; set; }
+        
+        // User who reported
+        public string ReportedByUserId { get; set; }
+        public string ReportedByUserName { get; set; }
+        public string ReportedByUserProfilePicture { get; set; }
+        
+        // Comment details if it's a comment report
+        public int? CommentId { get; set; }
+        public string CommentContent { get; set; }
+        public string CommentAuthorName { get; set; }
+        public string CommentAuthorProfilePicture { get; set; }
+        public int? ArticleId { get; set; }
+        public string ArticleTitle { get; set; }
+        
+        // Indicates if this is a parent comment (without a parent itself)
+        public bool IsParent { get; set; }
+        
+        // Indicates if the comment is blocked
+        public bool IsBlocked { get; set; }
+    }
+} 

--- a/Blog_App-iteration_1.1/Blog.Core/Services/CommentService.cs
+++ b/Blog_App-iteration_1.1/Blog.Core/Services/CommentService.cs
@@ -36,7 +36,7 @@ namespace Blog.Core.Services
             {
                 var comments = await _context.Comments
                     .Include(c => c.User)
-                    .Where(c => c.ArticleId == articleId)
+                    .Where(c => c.ArticleId == articleId && !c.IsBlocked)
                     .OrderBy(c => c.CreatedAt)
                     .ToListAsync();
 
@@ -250,6 +250,208 @@ namespace Blog.Core.Services
             }
 
             return (true, string.Empty);
+        }
+
+        /// <summary>
+        /// Reports a comment
+        /// </summary>
+        public async Task ReportCommentAsync(int commentId, string userId, string reason, string description)
+        {
+            var comment = await _context.Comments.FindAsync(commentId);
+            if (comment == null)
+            {
+                throw new ArgumentException(CommentConstants.Messages.CommentNotFound);
+            }
+
+            var user = await _context.Users.FindAsync(userId);
+            if (user == null)
+            {
+                throw new ArgumentException(PermissionConstants.Messages.UserNotFound);
+            }
+
+            // Don't allow users to report their own comments
+            if (comment.UserId == userId)
+            {
+                throw new ArgumentException("Users cannot report their own comments");
+            }
+
+            // Check if this user has already reported this comment
+            var existingReport = await _context.Reports
+                .FirstOrDefaultAsync(r => r.CommentId == commentId && r.ReportedByUserId == userId);
+
+            if (existingReport != null)
+            {
+                // Update existing report instead of creating a new one
+                existingReport.Reason = reason;
+                existingReport.Description = description;
+                existingReport.IsResolved = false;
+                existingReport.ResolvedAt = null;
+            }
+            else
+            {
+                // Create new report
+                var report = new Report
+                {
+                    CommentId = commentId,
+                    ReportedByUserId = userId,
+                    Reason = reason,
+                    Description = description,
+                    CreatedAt = DateTime.UtcNow,
+                    IsResolved = false
+                };
+
+                await _context.Reports.AddAsync(report);
+            }
+
+            await _context.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Sets the block status of a comment and all its replies
+        /// </summary>
+        public async Task<CommentViewModel> SetCommentBlockStatusAsync(int commentId, bool isBlocked)
+        {
+            var comment = await _context.Comments
+                .Include(c => c.User)
+                .FirstOrDefaultAsync(c => c.Id == commentId);
+
+            if (comment == null)
+            {
+                throw new ArgumentException(CommentConstants.Messages.CommentNotFound);
+            }
+
+            // Update the block status of the parent comment
+            comment.IsBlocked = isBlocked;
+            
+            // Find and update all replies to this comment if it's a parent comment
+            if (comment.ParentCommentId == null)
+            {
+                var replies = await _context.Comments
+                    .Where(c => c.ParentCommentId == commentId)
+                    .ToListAsync();
+                
+                // Log the number of replies affected
+                Console.WriteLine($"Updating block status for {replies.Count} replies to comment {commentId}");
+                
+                // Update each reply's block status to match the parent
+                foreach (var reply in replies)
+                {
+                    reply.IsBlocked = isBlocked;
+                }
+            }
+            
+            await _context.SaveChangesAsync();
+
+            // If blocking the comment, automatically resolve any reports
+            if (isBlocked)
+            {
+                // Get reports for both the comment and its replies
+                List<Report> reportsToResolve;
+                
+                if (comment.ParentCommentId == null)
+                {
+                    // If this is a parent comment, also get reports for all its replies
+                    reportsToResolve = await _context.Reports
+                        .Where(r => (r.CommentId == commentId || 
+                                    _context.Comments
+                                        .Where(c => c.ParentCommentId == commentId)
+                                        .Select(c => c.Id)
+                                        .Contains(r.CommentId.Value)) 
+                                && !r.IsResolved)
+                        .ToListAsync();
+                }
+                else
+                {
+                    // If this is a reply, just get reports for this comment
+                    reportsToResolve = await _context.Reports
+                        .Where(r => r.CommentId == commentId && !r.IsResolved)
+                        .ToListAsync();
+                }
+
+                foreach (var report in reportsToResolve)
+                {
+                    report.IsResolved = true;
+                    report.ResolvedAt = DateTime.UtcNow;
+                }
+
+                await _context.SaveChangesAsync();
+            }
+
+            return new CommentViewModel
+            {
+                Id = comment.Id,
+                Content = comment.Content,
+                CreatedAt = comment.CreatedAt,
+                UpdatedAt = comment.UpdatedAt,
+                UserId = comment.UserId,
+                UserName = $"{comment.User.FirstName} {comment.User.LastName}",
+                UserProfilePicture = comment.User.ProfilePicture,
+                ArticleId = comment.ArticleId,
+                ParentCommentId = comment.ParentCommentId,
+                IsBlocked = comment.IsBlocked
+            };
+        }
+
+        /// <summary>
+        /// Gets all reported comments for admin review
+        /// </summary>
+        public async Task<IEnumerable<ReportViewModel>> GetReportedCommentsAsync()
+        {
+            var reports = await _context.Reports
+                .Include(r => r.ReportedByUser)
+                .Include(r => r.Comment)
+                    .ThenInclude(c => c.User)
+                .Include(r => r.Comment)
+                    .ThenInclude(c => c.Article)
+                .Where(r => r.CommentId.HasValue)
+                .OrderByDescending(r => r.CreatedAt)
+                .ToListAsync();
+
+            return reports.Select(r => new ReportViewModel
+            {
+                Id = r.Id,
+                Reason = r.Reason,
+                Description = r.Description,
+                CreatedAt = r.CreatedAt,
+                IsResolved = r.IsResolved,
+                ResolvedAt = r.ResolvedAt,
+                ReportedByUserId = r.ReportedByUserId,
+                ReportedByUserName = $"{r.ReportedByUser.FirstName} {r.ReportedByUser.LastName}",
+                ReportedByUserProfilePicture = r.ReportedByUser.ProfilePicture,
+                CommentId = r.CommentId,
+                CommentContent = r.Comment?.Content,
+                CommentAuthorName = r.Comment != null ? $"{r.Comment.User.FirstName} {r.Comment.User.LastName}" : "",
+                CommentAuthorProfilePicture = r.Comment?.User?.ProfilePicture,
+                ArticleId = r.Comment?.ArticleId,
+                ArticleTitle = r.Comment?.Article?.Title,
+                IsParent = r.Comment?.ParentCommentId == null,
+                IsBlocked = r.Comment?.IsBlocked ?? false
+            });
+        }
+        
+        /// <summary>
+        /// Resolves or unresolves a report based on the isResolved parameter
+        /// </summary>
+        public async Task ResolveReportAsync(int reportId, bool isResolved = true)
+        {
+            var report = await _context.Reports.FindAsync(reportId);
+            if (report == null)
+            {
+                throw new ArgumentException("Report not found");
+            }
+            
+            report.IsResolved = isResolved;
+            
+            if (isResolved)
+            {
+                report.ResolvedAt = DateTime.UtcNow;
+            }
+            else
+            {
+                report.ResolvedAt = null;
+            }
+            
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/Blog_App-iteration_1.1/Blog.Infrastructure/Entities/Comment.cs
+++ b/Blog_App-iteration_1.1/Blog.Infrastructure/Entities/Comment.cs
@@ -34,7 +34,8 @@ namespace Blog.Infrastructure.Entities
         [ForeignKey("ParentCommentId")]
         public Comment ParentComment { get; set; }
         
-
+        // Flag to determine if comment is blocked by admin
+        public bool IsBlocked { get; set; }
         
         public virtual ICollection<Comment> Replies { get; set; }
         public virtual ICollection<Report> Reports { get; set; }
@@ -44,6 +45,7 @@ namespace Blog.Infrastructure.Entities
             Replies = new HashSet<Comment>();
             Reports = new HashSet<Report>();
             CreatedAt = DateTime.UtcNow;
+            IsBlocked = false;
         }
     }
 }

--- a/Blog_App-iteration_1.1/Blog.Web/Controllers/AdminController.cs
+++ b/Blog_App-iteration_1.1/Blog.Web/Controllers/AdminController.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using System.Threading.Tasks;
+using Blog.Infrastructure.Entities;
+using Blog.Core.Interfaces;
+using System.Linq;
+using Blog.Core.Constants;
+using Blog.Core.Models;
+using System;
+using Blog.Web.Models;
+
+namespace Blog.Web.Controllers
+{
+    [Authorize]
+    public class AdminController : Controller
+    {
+        private readonly UserManager<User> _userManager;
+        private readonly ICommentService _commentService;
+        
+        public AdminController(
+            UserManager<User> userManager,
+            ICommentService commentService)
+        {
+            _userManager = userManager;
+            _commentService = commentService;
+        }
+        
+        public async Task<IActionResult> Index()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || !user.IsAdmin)
+            {
+                return RedirectToAction(AdminConstants.Routes.Index, AdminConstants.Routes.Home);
+            }
+            
+            return View();
+        }
+        
+        [HttpGet]
+        public async Task<IActionResult> Reports()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || !user.IsAdmin)
+            {
+                return RedirectToAction(AdminConstants.Routes.Index, AdminConstants.Routes.Home);
+            }
+            
+            var reportedComments = await _commentService.GetReportedCommentsAsync();
+            return View(reportedComments);
+        }
+        
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> ResolveReport([FromBody] ResolveReportViewModel model)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || !user.IsAdmin)
+            {
+                return Forbid();
+            }
+            
+            try
+            {
+                await _commentService.ResolveReportAsync(model.ReportId, model.IsResolved);
+                
+                string message = model.IsResolved 
+                    ? AdminConstants.SuccessMessages.ReportResolved 
+                    : AdminConstants.SuccessMessages.ReportUnresolved;
+                
+                TempData[AdminConstants.ViewBagKeys.SuccessMessage] = message;
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+    }
+} 

--- a/Blog_App-iteration_1.1/Blog.Web/Models/CommentBlockViewModel.cs
+++ b/Blog_App-iteration_1.1/Blog.Web/Models/CommentBlockViewModel.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Blog.Web.Models
+{
+    public class CommentBlockViewModel
+    {
+        public int CommentId { get; set; }
+        public bool IsBlocked { get; set; }
+    }
+} 

--- a/Blog_App-iteration_1.1/Blog.Web/Models/CommentReportViewModel.cs
+++ b/Blog_App-iteration_1.1/Blog.Web/Models/CommentReportViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Blog.Web.Models
+{
+    public class CommentReportViewModel
+    {
+        public int CommentId { get; set; }
+        public string Reason { get; set; }
+        public string Description { get; set; }
+    }
+} 

--- a/Blog_App-iteration_1.1/Blog.Web/Models/ResolveReportViewModel.cs
+++ b/Blog_App-iteration_1.1/Blog.Web/Models/ResolveReportViewModel.cs
@@ -1,0 +1,8 @@
+namespace Blog.Web.Models
+{
+    public class ResolveReportViewModel
+    {
+        public int ReportId { get; set; }
+        public bool IsResolved { get; set; } = true;
+    }
+}

--- a/Blog_App-iteration_1.1/Blog.Web/Views/Admin/Reports.cshtml
+++ b/Blog_App-iteration_1.1/Blog.Web/Views/Admin/Reports.cshtml
@@ -1,0 +1,397 @@
+@model IEnumerable<Blog.Core.Models.ReportViewModel>
+@{
+    ViewData["Title"] = "Reported Comments";
+}
+
+<div class="container-fluid mt-4">
+    <h1 class="h2 mb-4">@ViewData["Title"]</h1>
+    
+    <div class="mb-4">
+        <div class="nav nav-pills">
+            <button type="button" class="nav-link active filter-btn me-2" data-filter="all">All Reports</button>
+            <button type="button" class="nav-link filter-btn me-2" data-filter="pending">Pending Reports</button>
+            <button type="button" class="nav-link filter-btn" data-filter="resolved">Resolved Reports</button>
+        </div>
+        <div class="nav nav-pills mt-2">
+            <button type="button" class="nav-link active block-filter-btn me-2" data-block-filter="all">All Comments</button>
+            <button type="button" class="nav-link block-filter-btn me-2" data-block-filter="blocked">Blocked Comments</button>
+            <button type="button" class="nav-link block-filter-btn" data-block-filter="unblocked">Unblocked Comments</button>
+        </div>
+    </div>
+    
+    @if (!Model.Any())
+    {
+        <div class="alert alert-info no-reports-message">
+            <p class="mb-0">There are no reported comments to review.</p>
+        </div>
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-hover align-middle" id="reports-table">
+                <thead>
+                    <tr>
+                        <th>Reported By</th>
+                        <th>Reason</th>
+                        <th>Comment</th>
+                        <th>Author</th>
+                        <th>Article</th>
+                        <th>Reported At</th>
+                        <th>Status</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var report in Model)
+                    {
+                        <tr class="report-row @(report.IsResolved ? "resolved" : "pending") @(report.IsBlocked ? "blocked" : "unblocked")">
+                            <td>
+                                <div class="d-flex align-items-center">
+                                    <img src="@(string.IsNullOrEmpty(report.ReportedByUserProfilePicture) ? "/images/default-profile.jpg" : report.ReportedByUserProfilePicture)" 
+                                         alt="@report.ReportedByUserName" 
+                                         class="rounded-circle me-2" width="32" height="32"
+                                         onerror="this.onerror=null; this.src='/images/default-profile.jpg';">
+                                    <span>@report.ReportedByUserName</span>
+                                </div>
+                            </td>
+                            <td>
+                                <div>
+                                    <strong class="text-danger">@report.Reason</strong>
+                                    @if (!string.IsNullOrEmpty(report.Description))
+                                    {
+                                        <p class="small text-muted mb-0">@report.Description</p>
+                                    }
+                                </div>
+                            </td>
+                            <td>
+                                <p class="mb-0 comment-content">@report.CommentContent</p>
+                            </td>
+                            <td>
+                                <div class="d-flex align-items-center">
+                                    <img src="@(string.IsNullOrEmpty(report.CommentAuthorProfilePicture) ? "/images/default-profile.jpg" : report.CommentAuthorProfilePicture)" 
+                                         alt="@report.CommentAuthorName" 
+                                         class="rounded-circle me-2" width="32" height="32"
+                                         onerror="this.onerror=null; this.src='/images/default-profile.jpg';">
+                                    <span>@report.CommentAuthorName</span>
+                                </div>
+                            </td>
+                            <td>
+                                <a href="@Url.Action("Details", "Articles", new { id = report.ArticleId })" target="_blank" class="text-decoration-none">
+                                    @report.ArticleTitle
+                                </a>
+                            </td>
+                            <td>
+                                @report.CreatedAt.ToString("MMM dd, yyyy HH:mm")
+                            </td>
+                            <td>
+                                @if (report.IsResolved)
+                                {
+                                    <span class="badge bg-success status-resolved">Resolved</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-warning status-pending">Pending</span>
+                                }
+                            </td>
+                            <td>
+                                <div class="d-flex gap-1">
+                                    @if (report.IsResolved)
+                                    {
+                                        if (report.IsBlocked)
+                                        {
+                                            <button type="button" class="btn btn-info btn-sm unblock-comment-btn" 
+                                                    data-id="@report.CommentId" data-action="unblock" data-is-parent="@report.IsParent">
+                                                <i class="bi bi-shield-check"></i> <span class="btn-unblock-text">Unblock</span>
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            <button type="button" class="btn btn-warning btn-sm block-comment-btn" 
+                                                    data-id="@report.CommentId" data-action="block" data-is-parent="@report.IsParent">
+                                                <i class="bi bi-shield-exclamation"></i> <span class="btn-block-text">Block</span>
+                                            </button>
+                                        }
+                                        
+                                        <button type="button" class="btn btn-warning btn-sm unresolve-report-btn" 
+                                                data-id="@report.Id" data-action="unresolve">
+                                            <i class="bi bi-x-lg"></i> <span class="btn-unresolve-text">Unresolve</span>
+                                        </button>
+                                    }
+                                    else
+                                    {
+                                        <button type="button" class="btn btn-warning btn-sm block-comment-btn" 
+                                                data-id="@report.CommentId" data-action="block" data-is-parent="@report.IsParent">
+                                            <i class="bi bi-shield-exclamation"></i> <span class="btn-block-text">Block</span>
+                                        </button>
+                                        <button type="button" class="btn btn-success btn-sm resolve-report-btn" 
+                                                data-id="@report.Id" data-action="resolve">
+                                            <i class="bi bi-check-lg"></i> <span class="btn-resolve-text">Resolve</span>
+                                        </button>
+                                    }
+                                    <a href="@Url.Action("Details", "Articles", new { id = report.ArticleId })" 
+                                       class="btn btn-primary btn-sm">
+                                        <i class="bi bi-eye"></i> <span class="btn-view-text">View</span>
+                                    </a>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</div>
+
+@section Scripts {
+    <script src="~/js/adminConstants.js"></script>
+    <script>
+        $(document).ready(function() {
+            // Add antiforgery token to the page if it doesn't exist
+            if ($('input[name="__RequestVerificationToken"]').length === 0) {
+                $('body').append('@Html.AntiForgeryToken()');
+            }
+            
+            // Update all default profile image URLs
+            $('img').each(function() {
+                $(this).attr('onerror', `this.onerror=null; this.src='${AdminConstants.Reports.Images.DefaultProfile}';`);
+            });
+            
+            // Update the text elements with constants
+            $('.no-reports-message p').text(AdminConstants.Reports.ErrorMessages.NoReportsFound);
+            $('.status-resolved').text(AdminConstants.Reports.Status.Resolved);
+            $('.status-pending').text(AdminConstants.Reports.Status.Pending);
+            $('.btn-block-text').text(AdminConstants.Reports.ButtonLabels.BlockComment);
+            $('.btn-unblock-text').text(AdminConstants.Reports.ButtonLabels.UnblockComment);
+            $('.btn-resolve-text').text(AdminConstants.Reports.ButtonLabels.Resolve);
+            $('.btn-unresolve-text').text(AdminConstants.Reports.ButtonLabels.Unresolve);
+            $('.btn-view-text').text(AdminConstants.Reports.ButtonLabels.View);
+            
+            // Update filter button labels
+            $('.filter-btn[data-filter="all"]').text(AdminConstants.Reports.FilterLabels.All);
+            $('.filter-btn[data-filter="resolved"]').text(AdminConstants.Reports.FilterLabels.Resolved);
+            $('.filter-btn[data-filter="pending"]').text(AdminConstants.Reports.FilterLabels.Pending);
+            $('.block-filter-btn[data-block-filter="all"]').text(AdminConstants.Reports.FilterLabels.AllComments);
+            $('.block-filter-btn[data-block-filter="blocked"]').text(AdminConstants.Reports.FilterLabels.BlockedComments);
+            $('.block-filter-btn[data-block-filter="unblocked"]').text(AdminConstants.Reports.FilterLabels.UnblockedComments);
+            
+            // Function to show success message
+            function showSuccessMessage(message) {
+                const alert = $(`
+                    <div class="alert alert-success alert-dismissible fade show" role="alert">
+                        <i class="bi bi-check-circle me-2"></i>
+                        ${message}
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                `);
+                
+                // Remove any existing alerts
+                $('.alert').remove();
+                
+                // Add the new alert at the top of the container
+                $('.container-fluid').prepend(alert);
+                
+                // Auto dismiss after 5 seconds
+                setTimeout(() => {
+                    alert.alert('close');
+                }, 5000);
+            }
+            
+            // Track current filter states
+            let currentStatusFilter = 'all';
+            let currentBlockFilter = 'all';
+            
+            // Apply status filters (resolved/pending)
+            $('.filter-btn').on('click', function() {
+                const filter = $(this).data('filter');
+                currentStatusFilter = filter;
+                
+                $('.filter-btn').removeClass('active');
+                $(this).addClass('active');
+                
+                applyFilters();
+            });
+            
+            // Apply block status filters (blocked/unblocked)
+            $('.block-filter-btn').on('click', function() {
+                const filter = $(this).data('block-filter');
+                currentBlockFilter = filter;
+                
+                $('.block-filter-btn').removeClass('active');
+                $(this).addClass('active');
+                
+                applyFilters();
+            });
+            
+            // Apply both filters
+            function applyFilters() {
+                // Hide all rows first
+                $('.report-row').hide();
+                
+                // Determine which rows to show based on filters
+                let selector = '.report-row';
+                
+                if (currentStatusFilter !== 'all') {
+                    selector += '.' + currentStatusFilter;
+                }
+                
+                if (currentBlockFilter !== 'all') {
+                    selector += '.' + currentBlockFilter;
+                }
+                
+                // Show rows that match both filters
+                $(selector).show();
+                
+                // Check if there are visible rows
+                const visibleRows = $('.report-row:visible').length;
+                if (visibleRows === 0) {
+                    if (!$('#no-filtered-results').length) {
+                        $('#reports-table').after('<div id="no-filtered-results" class="alert alert-info mt-3">' + 
+                            AdminConstants.Reports.ErrorMessages.NoFilteredResults + '</div>');
+                    }
+                } else {
+                    $('#no-filtered-results').remove();
+                }
+            }
+            
+            // Block comment button click
+            $(".block-comment-btn").on("click", function() {
+                const commentId = $(this).data("id");
+                const isParent = $(this).data("is-parent") === true;
+                
+                let confirmMessage = AdminConstants.Reports.Confirmation.BlockComment;
+                if (isParent) {
+                    confirmMessage = AdminConstants.Reports.Confirmation.BlockCommentWithReplies;
+                }
+                
+                if (confirm(confirmMessage)) {
+                    blockComment(commentId, true);
+                }
+            });
+            
+            // Unblock comment button click
+            $(".unblock-comment-btn").on("click", function() {
+                const commentId = $(this).data("id");
+                const isParent = $(this).data("is-parent") === true;
+                
+                if (confirm(AdminConstants.Reports.Confirmation.UnblockComment)) {
+                    blockComment(commentId, false);
+                }
+            });
+            
+            // Resolve report button click
+            $(".resolve-report-btn").on("click", function() {
+                const reportId = $(this).data("id");
+                if (confirm(AdminConstants.Reports.Confirmation.ResolveReport)) {
+                    resolveReport(reportId, true);
+                }
+            });
+            
+            // Unresolve report button click
+            $(".unresolve-report-btn").on("click", function() {
+                const reportId = $(this).data("id");
+                if (confirm(AdminConstants.Reports.Confirmation.UnresolveReport)) {
+                    resolveReport(reportId, false);
+                }
+            });
+            
+            // Block/unblock comment function
+            function blockComment(commentId, isBlocked) {
+                const url = isBlocked ? 
+                    AdminConstants.Reports.Urls.BlockComment : 
+                    AdminConstants.Reports.Urls.UnblockComment;
+                    
+                $.ajax({
+                    url: url,
+                    method: "POST",
+                    contentType: "application/json",
+                    data: JSON.stringify({
+                        commentId: parseInt(commentId),
+                        isBlocked: isBlocked
+                    }),
+                    beforeSend: function(xhr) {
+                        const token = $("input[name='__RequestVerificationToken']").val();
+                        xhr.setRequestHeader("RequestVerificationToken", token);
+                    },
+                    success: function() {
+                        showSuccessMessage(isBlocked ? 
+                            "Comment has been blocked successfully." : 
+                            "Comment has been unblocked successfully.");
+                        setTimeout(() => location.reload(), 1000);
+                    },
+                    error: function(error) {
+                        console.error(`Error ${isBlocked ? 'blocking' : 'unblocking'} comment:`, error);
+                        alert(isBlocked ? 
+                            AdminConstants.Reports.ErrorMessages.BlockCommentFailed : 
+                            AdminConstants.Reports.ErrorMessages.UnblockCommentFailed);
+                    }
+                });
+            }
+            
+            // Resolve/unresolve report function
+            function resolveReport(reportId, isResolved) {
+                $.ajax({
+                    url: AdminConstants.Reports.Urls.ResolveReport,
+                    method: "POST",
+                    contentType: "application/json",
+                    data: JSON.stringify({
+                        reportId: parseInt(reportId),
+                        isResolved: isResolved
+                    }),
+                    beforeSend: function(xhr) {
+                        const token = $("input[name='__RequestVerificationToken']").val();
+                        xhr.setRequestHeader("RequestVerificationToken", token);
+                    },
+                    success: function() {
+                        showSuccessMessage(isResolved ? 
+                            "Report has been resolved successfully." : 
+                            "Report has been marked as unresolved.");
+                        setTimeout(() => location.reload(), 1000);
+                    },
+                    error: function(error) {
+                        console.error(`Error ${isResolved ? 'resolving' : 'unresolving'} report:`, error);
+                        alert(AdminConstants.Reports.ErrorMessages.ResolveReportFailed);
+                    }
+                });
+            }
+        });
+    </script>
+}
+
+<style>
+    .comment-content {
+        max-width: 250px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    
+    .nav-pills .nav-link {
+        color: var(--bs-body-color);
+        background-color: transparent;
+        border: 1px solid var(--bs-border-color);
+    }
+    
+    .nav-pills .nav-link.active {
+        background-color: var(--bs-primary);
+        color: white;
+        border-color: var(--bs-primary);
+    }
+    
+    .table > :not(caption) > * > * {
+        padding: 1rem 0.75rem;
+    }
+    
+    .btn-group .btn {
+        border-radius: 4px !important;
+        margin: 0 2px;
+    }
+    
+    .alert {
+        margin-bottom: 1.5rem;
+    }
+    
+    .badge {
+        font-size: 0.85em;
+        padding: 0.5em 0.85em;
+    }
+</style> 

--- a/Blog_App-iteration_1.1/Blog.Web/Views/Articles/Details.cshtml
+++ b/Blog_App-iteration_1.1/Blog.Web/Views/Articles/Details.cshtml
@@ -128,6 +128,11 @@
             color: white;
         }
     </style>
+    
+    <!-- Set flag to prevent double initialization of comments -->
+    <script>
+        window.commentsInitializedByParent = true;
+    </script>
 }
 @section Scripts {
     <!-- jQuery first -->
@@ -197,11 +202,12 @@
                 var currentUserId = currentUser?.Id ?? string.Empty;
                 var canComment = currentUser != null && (currentUser.CanCommentArticles || currentUser.IsAdmin);
                 var profilePicture = currentUser?.ProfilePicture ?? "/images/default-profile.jpg";
+                var isAdmin = currentUser != null && currentUser.IsAdmin;
                 // Ensure article ID is a number
                 var articleId = ViewBag.ArticleId;
             }
             
-            console.log("Initializing comments with article ID: @articleId");
+            console.log("Parent view initializing comments with article ID: @articleId");
             
             // Check if function is defined before calling
             if (typeof initializeComments === 'function') {
@@ -209,7 +215,8 @@
                     currentUserId: '@(currentUserId)',
                     canComment: @Json.Serialize(canComment),
                     articleId: @articleId, // Pass as a number, not a string
-                    currentUserProfilePicture: '@(profilePicture)'
+                    currentUserProfilePicture: '@(profilePicture)',
+                    isAdmin: @Json.Serialize(isAdmin) // Pass admin status
                 });
             } else {
                 console.error("initializeComments function is not defined. Check if comments.js is loaded correctly.");

--- a/Blog_App-iteration_1.1/Blog.Web/Views/Shared/_CommentsPartial.cshtml
+++ b/Blog_App-iteration_1.1/Blog.Web/Views/Shared/_CommentsPartial.cshtml
@@ -5,6 +5,7 @@
 @{
     var currentUser = await UserManager.GetUserAsync(User);
     var canComment = currentUser != null && (currentUser.CanCommentArticles || currentUser.IsAdmin);
+    var isAdmin = currentUser?.IsAdmin ?? false;
     var profilePicture = currentUser?.ProfilePicture ?? "/images/default-profile.jpg";
     // Properly encode the profile picture URL for JavaScript
     var encodedProfilePicture = Html.Raw(Json.Serialize(profilePicture));
@@ -313,6 +314,7 @@
                             <div class="meta-left">
                                 <strong>{userName}</strong>
                                 <span class="text-muted">{createdAt}</span>
+                                <span class="badge bg-danger blocked-badge" style="display: {blockedDisplay};">Blocked</span>
                             </div>
                             @if (User.Identity.IsAuthenticated && canComment)
                             {
@@ -321,17 +323,23 @@
                                         <i class="bi bi-three-dots-vertical"></i>
                                     </button>
                                     <div class="kebab-menu-content">
-                                        <button class="edit-comment-btn" data-id="{id}">
+                                        <button class="edit-comment-btn" data-id="{id}" style="display: {ownerActionsDisplay}">
                                             <i class="bi bi-pencil"></i> Edit
                                         </button>
-                                        <button class="delete-comment-btn" data-id="{id}">
+                                        <button class="delete-comment-btn" data-id="{id}" style="display: {ownerActionsDisplay}">
                                             <i class="bi bi-trash"></i> Delete
+                                        </button>
+                                        <button class="report-comment-btn" data-id="{id}" style="display: {reportDisplay}">
+                                            <i class="bi bi-flag"></i> Report
+                                        </button>
+                                        <button class="block-comment-btn" data-id="{id}" data-is-blocked="{isBlocked}" style="display: {adminActionsDisplay}">
+                                            <i class="bi bi-shield-exclamation"></i> {blockActionText}
                                         </button>
                                     </div>
                                 </div>
                             }
                         </div>
-                        <p class="comment-content mb-1">{content}</p>
+                        <p class="comment-content mb-1" style="opacity: {contentOpacity};">{content}</p>
                         <div class="reply-action mt-1" style="display: {replyDisplay};">
                             <button class="btn btn-sm text-muted reply-comment-btn" data-id="{id}">
                                 <i class="bi bi-reply"></i> Reply
@@ -367,6 +375,7 @@
                         <div class="meta-left">
                             <strong>{userName}</strong>
                             <span class="text-muted">{createdAt}</span>
+                            <span class="badge bg-danger blocked-badge" style="display: {blockedDisplay};">Blocked</span>
                         </div>
                         @if (User.Identity.IsAuthenticated && canComment)
                         {
@@ -375,17 +384,23 @@
                                     <i class="bi bi-three-dots-vertical"></i>
                                 </button>
                                 <div class="kebab-menu-content">
-                                    <button class="edit-comment-btn" data-id="{id}">
+                                    <button class="edit-comment-btn" data-id="{id}" style="display: {ownerActionsDisplay}">
                                         <i class="bi bi-pencil"></i> Edit
                                     </button>
-                                    <button class="delete-comment-btn" data-id="{id}">
+                                    <button class="delete-comment-btn" data-id="{id}" style="display: {ownerActionsDisplay}">
                                         <i class="bi bi-trash"></i> Delete
+                                    </button>
+                                    <button class="report-comment-btn" data-id="{id}" style="display: {reportDisplay}">
+                                        <i class="bi bi-flag"></i> Report
+                                    </button>
+                                    <button class="block-comment-btn" data-id="{id}" data-is-blocked="{isBlocked}" style="display: {adminActionsDisplay}">
+                                        <i class="bi bi-shield-exclamation"></i> {blockActionText}
                                     </button>
                                 </div>
                             </div>
                         }
                     </div>
-                    <p class="comment-content mb-1">{content}</p>
+                    <p class="comment-content mb-1" style="opacity: {contentOpacity};">{content}</p>
                 </div>
             </div>
         </div>
@@ -413,5 +428,43 @@
         });
         // Toggle this menu
         menu.classList.toggle('show');
+    }
+
+    // Initialize only if not already initialized or being initialized by parent view
+    // This prevents double initialization when included in Details.cshtml
+    if (!window.commentsInitializedByParent) {
+        document.addEventListener('DOMContentLoaded', function() {
+            console.log("Comments partial initializing comments system");
+            // Include API Endpoints if not already included
+            if (typeof API_ENDPOINTS === 'undefined') {
+                loadScript('/js/apiEndpoints.js', function() {
+                    loadCommentsScript();
+                });
+            } else {
+                loadCommentsScript();
+            }
+        });
+    } else {
+        console.log("Comments will be initialized by parent view");
+    }
+    
+    function loadScript(url, callback) {
+        const script = document.createElement('script');
+        script.src = url;
+        script.onload = callback;
+        document.head.appendChild(script);
+    }
+    
+    function loadCommentsScript() {
+        loadScript('/js/comments.js', function() {
+            // Initialize with the current user details
+            window.initializeComments({
+                currentUserId: '@(currentUser?.Id ?? "")',
+                canComment: @Json.Serialize(canComment),
+                articleId: @ViewBag.ArticleId,
+                currentUserProfilePicture: @encodedProfilePicture,
+                isAdmin: @Json.Serialize(isAdmin) // Pass isAdmin flag to the comments system
+            });
+        });
     }
 </script> 

--- a/Blog_App-iteration_1.1/Blog.Web/Views/Shared/_Layout.cshtml
+++ b/Blog_App-iteration_1.1/Blog.Web/Views/Shared/_Layout.cshtml
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/Blog.Web.styles.css" asp-append-version="true" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body>
@@ -37,6 +38,14 @@
                                     <a class="nav-link text-dark" asp-area="" asp-controller="Articles" asp-action="Create">Create Article</a>
                                 </li>
                             }
+                            @if ((await UserManager.GetUserAsync(User)).IsAdmin)
+                            {
+                                <li class="nav-item">
+                                    <a class="nav-link text-dark" asp-area="" asp-controller="Admin" asp-action="Reports">
+                                        <i class="bi bi-flag"></i> Reported Comments
+                                    </a>
+                                </li>
+                            }
                         }
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
@@ -58,6 +67,12 @@
             &copy; 2025 - Blog.Web - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
         </div>
     </footer>
+    
+    <!-- Anti-forgery token for AJAX requests -->
+    <form id="antiForgeryForm" style="display:none;">
+        @Html.AntiForgeryToken()
+    </form>
+    
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>

--- a/Blog_App-iteration_1.1/Blog.Web/wwwroot/js/adminConstants.js
+++ b/Blog_App-iteration_1.1/Blog.Web/wwwroot/js/adminConstants.js
@@ -1,0 +1,48 @@
+// Admin constants for the admin section of the application
+window.AdminConstants = {
+    Reports: {
+        Urls: {
+            BlockComment: '/Comments/Block',
+            ResolveReport: '/Admin/ResolveReport',
+            UnblockComment: '/Comments/Block'
+        },
+        Confirmation: {
+            BlockComment: "Are you sure you want to block this comment?",
+            BlockCommentWithReplies: "Are you sure you want to block this comment? This will also block all replies to this comment.",
+            ResolveReport: "Are you sure you want to mark this report as resolved?",
+            UnblockComment: "Are you sure you want to unblock this comment? This will also unblock all replies to this comment.",
+            UnresolveReport: "Are you sure you want to mark this report as unresolved?"
+        },
+        ErrorMessages: {
+            BlockCommentFailed: "Failed to block comment. Please try again later.",
+            ResolveReportFailed: "Failed to resolve report. Please try again later.",
+            NoReportsFound: "There are no reported comments to review.",
+            UnblockCommentFailed: "Failed to unblock comment. Please try again later.",
+            NoFilteredResults: "No reports match the current filters."
+        },
+        Images: {
+            DefaultProfile: "/images/default-profile.jpg"
+        },
+        Status: {
+            Resolved: "Resolved",
+            Pending: "Pending",
+            Blocked: "Blocked",
+            Unblocked: "Unblocked"
+        },
+        ButtonLabels: {
+            BlockComment: "Block Comment",
+            UnblockComment: "Unblock Comment",
+            Resolve: "Resolve",
+            Unresolve: "Unresolve",
+            View: "View"
+        },
+        FilterLabels: {
+            All: "All Reports",
+            Resolved: "Resolved Reports",
+            Pending: "Pending Reports",
+            AllComments: "All Comments",
+            BlockedComments: "Blocked Comments",
+            UnblockedComments: "Unblocked Comments"
+        }
+    }
+}; 

--- a/Blog_App-iteration_1.1/Blog.Web/wwwroot/js/apiEndpoints.js
+++ b/Blog_App-iteration_1.1/Blog.Web/wwwroot/js/apiEndpoints.js
@@ -5,6 +5,14 @@ const API_ENDPOINTS = {
     },
     ARTICLE_VOTES: {
         VOTE: '/api/articlevotes/vote'
+    },
+    COMMENTS: {
+        GET_ARTICLE_COMMENTS: '/Comments/Article/',
+        CREATE: '/Comments',
+        UPDATE: '/Comments/',  // Append comment ID
+        DELETE: '/Comments/',  // Append comment ID
+        REPORT: '/Comments/Report',
+        BLOCK: '/Comments/Block'
     }
 };
 


### PR DESCRIPTION
I Added methods for reporting comments and setting block status for the ones reported. Reports can be resolved, unresolved, blocked and unblocked. Admin has a new view for reported comments, where he can also filter based on pending, resolved and blocked status. Users can't block their own comments, but can report any other. Admin has custom option to block a comment directly in the comments view.
1. Image of new admin view page with filtering and action buttons:
![image](https://github.com/user-attachments/assets/36ef90fb-86f1-4ad5-abaa-f6a52574c4e3)
2. Report option for users with comment allowance:
![image](https://github.com/user-attachments/assets/39ac101f-581e-4340-8e3e-8952a424de45)
3. Report view for users with reason selection and comment mesage field:
![image](https://github.com/user-attachments/assets/c0e45b93-14bb-4326-895c-c02ed33f53b3)
